### PR TITLE
Remove superfluous print statement

### DIFF
--- a/cli-client.go
+++ b/cli-client.go
@@ -271,7 +271,6 @@ func (c *cliClient) retreiveAWSEnv(role, MFA string) (awsEnv, error) {
 		return awsEnv{}, err
 	}
 
-	fmt.Println("client got region: ", r.Region)
 	creds := awsEnv{
 		AccessKeyID:     r.AccessKeyId,
 		SecretAccessKey: r.SecretAccessKey,


### PR DESCRIPTION
This printing to stdout interferes with the output of "limes env", so
that when passing it to eval the shell chokes on "client got region:
[...]" not being a valid command.